### PR TITLE
Fix for #5 and #6

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ Email on Away Plugin Changelog
 <p><b>1.1.0</b> -- To Be Determined.</p>
 <ul>
     <li>Now requires Openfire 4.4.0 or later.</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-emailOnAway-plugin/issues/6'>#6</a>] - Make using XMPP address as email address configurable</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-emailOnAway-plugin/issues/5'>#5</a>] - Use email template</li>
 </ul>
 

--- a/changelog.html
+++ b/changelog.html
@@ -44,9 +44,10 @@
 Email on Away Plugin Changelog
 </h1>
 
-<p><b>1.0.5</b> -- To Be Determined.</p>
+<p><b>1.1.0</b> -- To Be Determined.</p>
 <ul>
     <li>Now requires Openfire 4.4.0 or later.</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-emailOnAway-plugin/issues/5'>#5</a>] - Use email template</li>
 </ul>
 
 <p><b>1.0.4</b> -- November 27, 2023</p>

--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ Email on Away Plugin Changelog
 
 <p><b>1.0.5</b> -- To Be Determined.</p>
 <ul>
+    <li>Now requires Openfire 4.4.0 or later.</li>
 </ul>
 
 <p><b>1.0.4</b> -- November 27, 2023</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin>
     <!-- Main plugin class -->
-    <class>com.tempstop.emailOnAway</class>
+    <class>com.tempstop.EmailOnAwayPlugin</class>
 
     <name>Email on Away</name>
     <description>Messages sent to alternate location when recipient is away</description>
     <author>Nick Mossie</author>
     <version>${project.version}</version>
-    <date>2023-11-27</date>
-    <minServerVersion>4.0.0</minServerVersion>
+    <date>2023-12-27</date>
+    <minServerVersion>4.4.0</minServerVersion>
 
 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>emailOnAway</artifactId>
-    <version>1.0.5-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <name>Email On Away Plugin</name>
     <description>Messages sent to alternate location when recipient is away</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-beta</version>
+        <version>4.4.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>emailOnAway</artifactId>

--- a/readme.html
+++ b/readme.html
@@ -71,6 +71,8 @@ installation or install it via Admin Console. The plugin will then be automatica
 <p>
     To HTML body of the email that is being sent defined in the system property "plugin.emailonaway.email.body.html". When this value contains <tt>$$IMBODY$$</tt> then that will be replaced by the body of the chat message that was missed.
 </p>
-
+<p>
+    The plugin will try to look up the email address of senders and recipients of chat messages, but an email address can not always be found. The system property "plugin.emailonaway.use_xmpp_as_email_address" defines if the (bare) XMPP address of a user is to be used as an email address if no other address can be found. When configured to 'false', then the value from the system property "plugin.emailonaway.email.default_mail_address" will be used.
+</p>
 </body>
 </html>

--- a/readme.html
+++ b/readme.html
@@ -57,9 +57,19 @@ installation or install it via Admin Console. The plugin will then be automatica
 
 <h2>Configuration</h2>
 <p>
-Configuration can be changed and tested in Admin Console > Server Manager > Email settings.
-To not show email in the automated message create a system property "plugin.emailonaway.showemail" with
-the value "false".
+    Configuration can be changed and tested in Admin Console > Server Manager > Email settings.
+<p>
+<p>
+    To not show email in the automated message create a system property "plugin.emailonaway.showemail" with the value "false".
+</p>
+<p>
+    To subject of the email that is being sent is defined in the system property "plugin.emailonaway.email.subject"
+</p>
+<p>
+    To plain-text body of the email that is being sent defined in the system property "plugin.emailonaway.email.body.plain". When this value contains <tt>$$IMBODY$$</tt> then that will be replaced by the body of the chat message that was missed.
+</p>
+<p>
+    To HTML body of the email that is being sent defined in the system property "plugin.emailonaway.email.body.html". When this value contains <tt>$$IMBODY$$</tt> then that will be replaced by the body of the chat message that was missed.
 </p>
 
 </body>

--- a/src/i18n/emailonaway_i18n.properties
+++ b/src/i18n/emailonaway_i18n.properties
@@ -1,0 +1,1 @@
+system_property.plugin.emailonaway.showemail=Controls if the e-mail address of the intended recipient is sent in the confirmation message that is sent to the originator.

--- a/src/i18n/emailonaway_i18n.properties
+++ b/src/i18n/emailonaway_i18n.properties
@@ -2,3 +2,5 @@ system_property.plugin.emailonaway.showemail=Controls if the e-mail address of t
 system_property.plugin.emailonaway.email.subject=The subject of emails that are being sent.
 system_property.plugin.emailonaway.email.body.plain=The plain-text body of emails that are being sent. $$IMBODY$$ will be replaced with the body of the chat message that was missed.
 system_property.plugin.emailonaway.email.body.html=The HTML body of emails that are being sent. $$IMBODY$$ will be replaced with the body of the chat message that was missed.
+system_property.plugin.emailonaway.email.default_mail_address=Controls if the XMPP address is used as an e-mail address if no other email address could be looked up.
+system_property.plugin.emailonaway.use_xmpp_as_email_address=The default email address, to be used when no email address can be looked up for a user.

--- a/src/i18n/emailonaway_i18n.properties
+++ b/src/i18n/emailonaway_i18n.properties
@@ -1,1 +1,4 @@
 system_property.plugin.emailonaway.showemail=Controls if the e-mail address of the intended recipient is sent in the confirmation message that is sent to the originator.
+system_property.plugin.emailonaway.email.subject=The subject of emails that are being sent.
+system_property.plugin.emailonaway.email.body.plain=The plain-text body of emails that are being sent. $$IMBODY$$ will be replaced with the body of the chat message that was missed.
+system_property.plugin.emailonaway.email.body.html=The HTML body of emails that are being sent. $$IMBODY$$ will be replaced with the body of the chat message that was missed.

--- a/src/java/com/tempstop/EmailOnAwayPlugin.java
+++ b/src/java/com/tempstop/EmailOnAwayPlugin.java
@@ -15,22 +15,38 @@ import org.jivesoftware.openfire.PresenceManager;
 import org.jivesoftware.openfire.vcard.VCardManager;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.EmailService;
+import org.jivesoftware.util.SystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 import org.xmpp.packet.Packet;
 
 //import java.io.File;
 import java.io.*;
 
-public class emailOnAway implements Plugin, PacketInterceptor {
+public class EmailOnAwayPlugin implements Plugin, PacketInterceptor
+{
+    /**
+     * Controls if the e-mail address of the intended recipient is sent in the confirmation message that is sent to the
+     * originator.
+     */
+    public final SystemProperty<Boolean> SHOW_EMAIL = SystemProperty.Builder.ofType(Boolean.class)
+        .setKey("plugin.emailonaway.showemail")
+        .setPlugin("Email on Away")
+        .setDefaultValue(true)
+        .setDynamic(true)
+        .build();
 
-    private InterceptorManager interceptorManager;
-    private UserManager userManager;
-    private PresenceManager presenceManager;
-    private EmailService emailService;
-    private MessageRouter messageRouter;
-    private VCardManager vcardManager;
+    private static final Logger Log = LoggerFactory.getLogger(EmailOnAwayPlugin.class);
+    private final InterceptorManager interceptorManager;
+    private final UserManager userManager;
+    private final PresenceManager presenceManager;
+    private final EmailService emailService;
+    private final MessageRouter messageRouter;
+    private final VCardManager vcardManager;
 
-    public emailOnAway() {
+    public EmailOnAwayPlugin() {
         interceptorManager = InterceptorManager.getInstance();
         emailService = EmailService.getInstance();
         messageRouter = XMPPServer.getInstance().getMessageRouter();
@@ -49,44 +65,46 @@ public class emailOnAway implements Plugin, PacketInterceptor {
         interceptorManager.removeInterceptor(this);
     }
 
-    private Message createServerMessage(String to, String from, String emailTo) {
-        Message message = new Message();
+    private Message createServerMessage(JID to, JID from, String emailTo) {
+        final Message message = new Message();
         message.setTo(to);
         message.setFrom(from);
         message.setSubject("I'm away");
-        if (JiveGlobals.getBooleanProperty("plugin.emailonaway.showemail", true)) {
+        if (SHOW_EMAIL.getValue()) {
             message.setBody("I'm currently away. Your message has been forwarded to my email address  (" + emailTo + ").");
-        } else { message.setBody("I'm currently away. Your message has been forwarded to my email address."); }
+        } else {
+            message.setBody("I'm currently away. Your message has been forwarded to my email address.");
+        }
         return message;
     }
 
     public void interceptPacket(Packet packet, Session session, boolean read,
-                                boolean processed) throws PacketRejectedException {
-
-        String emailTo = null;
-        String emailFrom = null;
+                                boolean processed) throws PacketRejectedException
+    {
+        String emailTo;
+        String emailFrom;
 
         if((!processed) &&
             (!read) &&
             (packet instanceof Message) &&
-            (packet.getTo() != null)) {
-
+            (packet.getTo() != null))
+        {
             Message msg = (Message) packet;
 
             if(msg.getType() == Message.Type.chat) {
                 try {
                     User userTo = userManager.getUser(packet.getTo().getNode());
-                    if(presenceManager.getPresence(userTo).toString().toLowerCase().indexOf("away") != -1) {
+                    if(presenceManager.getPresence(userTo).toString().toLowerCase().contains("away")) {
                         // Status isn't away
                         if(msg.getBody() != null) {
                             // Build email/sms
                             // The to email address
                             emailTo = vcardManager.getVCardProperty(userTo.getUsername(), "EMAIL");
-                            if(emailTo == null || emailTo.length() == 0) {
+                            if(emailTo == null || emailTo.isEmpty()) {
                                 emailTo = vcardManager.getVCardProperty(userTo.getUsername(), "EMAIL:USERID");
-                                if(emailTo == null || emailTo.length() == 0) {
+                                if(emailTo == null || emailTo.isEmpty()) {
                                     emailTo = userTo.getEmail();
-                                    if(emailTo == null || emailTo.length() == 0) {
+                                    if(emailTo == null || emailTo.isEmpty()) {
                                         emailTo = packet.getTo().getNode() + "@" + packet.getTo().getDomain();
                                     }
                                 }
@@ -94,17 +112,16 @@ public class emailOnAway implements Plugin, PacketInterceptor {
                             // The From email address
                             User userFrom = userManager.getUser(packet.getFrom().getNode());
                             emailFrom = vcardManager.getVCardProperty(userFrom.getUsername(), "EMAIL");
-                            if(emailFrom == null || emailFrom.length() == 0) {
+                            if(emailFrom == null || emailFrom.isEmpty()) {
                                 emailFrom = vcardManager.getVCardProperty(userFrom.getUsername(), "EMAIL:USERID");
-                                if(emailFrom == null || emailFrom.length() == 0) {
+                                if(emailFrom == null || emailFrom.isEmpty()) {
                                     emailFrom = userFrom.getEmail();
-                                    if(emailFrom == null || emailFrom.length() == 0) {
+                                    if(emailFrom == null || emailFrom.isEmpty()) {
                                         emailFrom = packet.getFrom().getNode() + "@" + packet.getFrom().getDomain();
                                     }
                                 }
                             }
 
-//			    System.err.println(vcardManager.getVCardProperty(userTo.getUsername(), "EMAIL:USERID"));
                             // Send email/sms
                             // if this is an sms... modify the recipient address
                             emailService.sendMessage(userTo.getName(),
@@ -116,11 +133,11 @@ public class emailOnAway implements Plugin, PacketInterceptor {
                                 null);
 
                             // Notify the sender that this went to email/sms
-                            messageRouter.route(createServerMessage(packet.getFrom().getNode() + "@" + packet.getFrom().getDomain(), packet.getTo().getNode() + "@" + packet.getTo().getDomain(), emailTo));
-
+                            messageRouter.route(createServerMessage(packet.getFrom().asBareJID(), packet.getTo().asBareJID(), emailTo));
                         }
                     }
                 } catch (UserNotFoundException e) {
+                    Log.debug("Unable to determine if an email should be sent to a user that is away, as the user '{}' cannot be found.", packet.getTo(), e);
                 }
             }
         }

--- a/src/java/com/tempstop/emailOnAway.java
+++ b/src/java/com/tempstop/emailOnAway.java
@@ -29,14 +29,14 @@ public class emailOnAway implements Plugin, PacketInterceptor {
     private EmailService emailService;
     private MessageRouter messageRouter;
     private VCardManager vcardManager;
-    
+
     public emailOnAway() {
         interceptorManager = InterceptorManager.getInstance();
-    emailService = EmailService.getInstance();
+        emailService = EmailService.getInstance();
         messageRouter = XMPPServer.getInstance().getMessageRouter();
-    presenceManager = XMPPServer.getInstance().getPresenceManager();
-    userManager = XMPPServer.getInstance().getUserManager();
-    vcardManager = VCardManager.getInstance();
+        presenceManager = XMPPServer.getInstance().getPresenceManager();
+        userManager = XMPPServer.getInstance().getUserManager();
+        vcardManager = VCardManager.getInstance();
     }
 
     public void initializePlugin(PluginManager pManager, File pluginDirectory) {
@@ -54,75 +54,75 @@ public class emailOnAway implements Plugin, PacketInterceptor {
         message.setTo(to);
         message.setFrom(from);
         message.setSubject("I'm away");
-        if (JiveGlobals.getBooleanProperty("plugin.emailonaway.showemail", true)) { 
-            message.setBody("I'm currently away. Your message has been forwarded to my email address  (" + emailTo + ")."); 
-            } else { message.setBody("I'm currently away. Your message has been forwarded to my email address."); }
+        if (JiveGlobals.getBooleanProperty("plugin.emailonaway.showemail", true)) {
+            message.setBody("I'm currently away. Your message has been forwarded to my email address  (" + emailTo + ").");
+        } else { message.setBody("I'm currently away. Your message has been forwarded to my email address."); }
         return message;
     }
 
     public void interceptPacket(Packet packet, Session session, boolean read,
-            boolean processed) throws PacketRejectedException {
-    
-    String emailTo = null;
-    String emailFrom = null;
+                                boolean processed) throws PacketRejectedException {
 
-    if((!processed) && 
-        (!read) && 
-        (packet instanceof Message) && 
-        (packet.getTo() != null)) { 
+        String emailTo = null;
+        String emailFrom = null;
 
-        Message msg = (Message) packet;
-        
-        if(msg.getType() == Message.Type.chat) {
-        try {
-            User userTo = userManager.getUser(packet.getTo().getNode());
-            if(presenceManager.getPresence(userTo).toString().toLowerCase().indexOf("away") != -1) {
-            // Status isn't away
-            if(msg.getBody() != null) {
-                // Build email/sms
-                // The to email address
-                emailTo = vcardManager.getVCardProperty(userTo.getUsername(), "EMAIL");
-                if(emailTo == null || emailTo.length() == 0) {
-                emailTo = vcardManager.getVCardProperty(userTo.getUsername(), "EMAIL:USERID");
-                if(emailTo == null || emailTo.length() == 0) {
-                    emailTo = userTo.getEmail();
-                    if(emailTo == null || emailTo.length() == 0) {
-                    emailTo = packet.getTo().getNode() + "@" + packet.getTo().getDomain();
-                    }
-                }
-                }
-                // The From email address
-                User userFrom = userManager.getUser(packet.getFrom().getNode());
-                emailFrom = vcardManager.getVCardProperty(userFrom.getUsername(), "EMAIL");
-                if(emailFrom == null || emailFrom.length() == 0) {
-                emailFrom = vcardManager.getVCardProperty(userFrom.getUsername(), "EMAIL:USERID");
-                if(emailFrom == null || emailFrom.length() == 0) {
-                    emailFrom = userFrom.getEmail();
-                    if(emailFrom == null || emailFrom.length() == 0) {
-                    emailFrom = packet.getFrom().getNode() + "@" + packet.getFrom().getDomain();
-                    }
-                }
-                }
+        if((!processed) &&
+            (!read) &&
+            (packet instanceof Message) &&
+            (packet.getTo() != null)) {
+
+            Message msg = (Message) packet;
+
+            if(msg.getType() == Message.Type.chat) {
+                try {
+                    User userTo = userManager.getUser(packet.getTo().getNode());
+                    if(presenceManager.getPresence(userTo).toString().toLowerCase().indexOf("away") != -1) {
+                        // Status isn't away
+                        if(msg.getBody() != null) {
+                            // Build email/sms
+                            // The to email address
+                            emailTo = vcardManager.getVCardProperty(userTo.getUsername(), "EMAIL");
+                            if(emailTo == null || emailTo.length() == 0) {
+                                emailTo = vcardManager.getVCardProperty(userTo.getUsername(), "EMAIL:USERID");
+                                if(emailTo == null || emailTo.length() == 0) {
+                                    emailTo = userTo.getEmail();
+                                    if(emailTo == null || emailTo.length() == 0) {
+                                        emailTo = packet.getTo().getNode() + "@" + packet.getTo().getDomain();
+                                    }
+                                }
+                            }
+                            // The From email address
+                            User userFrom = userManager.getUser(packet.getFrom().getNode());
+                            emailFrom = vcardManager.getVCardProperty(userFrom.getUsername(), "EMAIL");
+                            if(emailFrom == null || emailFrom.length() == 0) {
+                                emailFrom = vcardManager.getVCardProperty(userFrom.getUsername(), "EMAIL:USERID");
+                                if(emailFrom == null || emailFrom.length() == 0) {
+                                    emailFrom = userFrom.getEmail();
+                                    if(emailFrom == null || emailFrom.length() == 0) {
+                                        emailFrom = packet.getFrom().getNode() + "@" + packet.getFrom().getDomain();
+                                    }
+                                }
+                            }
 
 //			    System.err.println(vcardManager.getVCardProperty(userTo.getUsername(), "EMAIL:USERID"));
-                // Send email/sms
-                // if this is an sms... modify the recipient address
-                emailService.sendMessage(userTo.getName(), 
-                emailTo, 
-                userFrom.getName(), 
-                emailFrom,
-                "IM",
-                msg.getBody(), 
-                null);
-                
-                // Notify the sender that this went to email/sms
-                messageRouter.route(createServerMessage(packet.getFrom().getNode() + "@" + packet.getFrom().getDomain(), packet.getTo().getNode() + "@" + packet.getTo().getDomain(), emailTo));
+                            // Send email/sms
+                            // if this is an sms... modify the recipient address
+                            emailService.sendMessage(userTo.getName(),
+                                emailTo,
+                                userFrom.getName(),
+                                emailFrom,
+                                "IM",
+                                msg.getBody(),
+                                null);
 
+                            // Notify the sender that this went to email/sms
+                            messageRouter.route(createServerMessage(packet.getFrom().getNode() + "@" + packet.getFrom().getDomain(), packet.getTo().getNode() + "@" + packet.getTo().getDomain(), emailTo));
+
+                        }
+                    }
+                } catch (UserNotFoundException e) {
+                }
             }
-            }
-        } catch (UserNotFoundException e) {
         }
-        }
-    }
     }
 }


### PR DESCRIPTION
This PR introduces a bit of basic maintenance, but also three properties that can be used to change the emails that are being sent by this plugin:
- `plugin.emailonaway.email.subject` The subject of emails that are being sent.
- `plugin.emailonaway.email.body.plain` The plain-text body of emails that are being sent. `$$IMBODY$$` will be replaced with the body of the chat message that was missed.
- `plugin.emailonaway.email.body.html` The html-text body of emails that are being sent. `$$IMBODY$$` will be replaced with the body of the chat message that was missed.
    
The plugin will try to look up the email address of senders and recipients of chat messages, but an email address can not always be found. The system property `plugin.emailonaway.use_xmpp_as_email_address` defines if the (bare) XMPP address of a user is to be used as an email address if no other address can be found. When configured to 'false', then the value from the system property `plugin.emailonaway.email.default_mail_address` will be used.
    
To implement the above, a refactoring has been implemented for the lookup of both the 'human name' as well as email address for an XMPP address.
